### PR TITLE
jefkin: Upgrade constructor to PHP7 standards.

### DIFF
--- a/Xtea.php
+++ b/Xtea.php
@@ -133,7 +133,7 @@ class Crypt_Xtea extends PEAR
     var $n_iter;
 
 
-    // {{{ Crypt_Xtea()
+    // {{{ Crypt_Xtea:__construct()
 
     /**
      *  Constructor, sets the number of iterations.
@@ -142,7 +142,7 @@ class Crypt_Xtea extends PEAR
      *  @author         Jeroen Derks <jeroen@derks.it>
      *  @see            setIter()
      */
-    function Crypt_Xtea()
+    function __construct()
     {
         $this->setIter(32);
     }


### PR DESCRIPTION
1]  PHP 7 sends nasty error notices on Instantiation of a class that
    uses the old Function with the same name as the Class.  This
    commit simply replaces that with the default __construct instead.

-	modified:   Xtea.php