### PR TITLE
deprecate _hex2bin

### DIFF
--- a/Xtea.php
+++ b/Xtea.php
@@ -434,19 +434,12 @@ class Crypt_Xtea extends PEAR
     // {{{ _hex2bin()
 
     /**
-     *  Convert a hexadecimal string to a binary string (e.g. convert "616263" to "abc").
-     *
-     *  @param  string  $str    Hexadecimal string to convert to binary string.
-     *
-     *  @return string          Binary string.
-     *
-     *  @access private
-     *  @author         Jeroen Derks <jeroen@derks.it>
+     * deprecated function, use PHP's native hex2bin() instead.
      */
     function _hex2bin($str)
     {
-        $len = strlen($str);
-        return pack('H' . $len, $str);
+        trigger_error( "_hex2bin is deprecated, use php's native hex2bin() instead.", E_USER_DEPRECATED);
+        return hex2bin($str);
     }
 
     // }}}


### PR DESCRIPTION
this removes support for  PHP older than 5.4, but that is no longer an issue.
and nobody should use this function anyway, should just use php's native hex2bin (as of PHP 5.4)

(also the function was never used within the project itself)